### PR TITLE
Fix issue where search facet dropdown opens behind SessionTile

### DIFF
--- a/frontend/packages/volto-ploneconf-core/news/8.bugfix
+++ b/frontend/packages/volto-ploneconf-core/news/8.bugfix
@@ -1,0 +1,1 @@
+Fix issue where search facet dropdown opens behind SessionTile, because SessionTile uses Container with z-index: 10 in volto-light-theme @datakurre

--- a/frontend/packages/volto-ploneconf-core/src/theme/_main.scss
+++ b/frontend/packages/volto-ploneconf-core/src/theme/_main.scss
@@ -4,6 +4,7 @@
 @import 'components/presenter_category';
 @import 'components/blocks/listing';
 @import 'components/blocks/schedule';
+@import 'components/blocks/search';
 @import 'components/views/presenter_view';
 @import 'components/views/session_view';
 @import 'components/views/sponsor_view';

--- a/frontend/packages/volto-ploneconf-core/src/theme/components/blocks/_search.scss
+++ b/frontend/packages/volto-ploneconf-core/src/theme/components/blocks/_search.scss
@@ -1,0 +1,5 @@
+// Fix issue where search facet dropdown opens behind SessionTile, because
+// SessionTile uses Container with z-index: 10 in volto-light-theme.
+.react-select-container {
+  z-index: 11;
+}


### PR DESCRIPTION
 because SessionTile uses Container with z-index: 10 in volto-light-theme

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [ ] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

