### PR TITLE
Fix session language on session tile to render capitalized

### DIFF
--- a/frontend/packages/volto-ploneconf-core/news/9.bugfix
+++ b/frontend/packages/volto-ploneconf-core/news/9.bugfix
@@ -1,0 +1,1 @@
+Fix session language on session tile to render capitalized @datakurre

--- a/frontend/packages/volto-ploneconf-core/src/theme/_main.scss
+++ b/frontend/packages/volto-ploneconf-core/src/theme/_main.scss
@@ -1,5 +1,6 @@
 @import 'root';
 @import 'components/navigation';
+@import 'components/sessiontile';
 @import 'components/sponsortile';
 @import 'components/presenter_category';
 @import 'components/blocks/listing';

--- a/frontend/packages/volto-ploneconf-core/src/theme/components/_sessiontile.scss
+++ b/frontend/packages/volto-ploneconf-core/src/theme/components/_sessiontile.scss
@@ -1,0 +1,5 @@
+.sessionTile {
+  .sessionLanguage {
+    text-transform: capitalize;
+  }
+}


### PR DESCRIPTION
This on is matter of taste, but lower case language was reported as a bug :roll_eyes: 

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [ ] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

